### PR TITLE
Add base package with no pyqt dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Current release info
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-qtconsole-green.svg)](https://anaconda.org/conda-forge/qtconsole) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/qtconsole.svg)](https://anaconda.org/conda-forge/qtconsole) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/qtconsole.svg)](https://anaconda.org/conda-forge/qtconsole) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/qtconsole.svg)](https://anaconda.org/conda-forge/qtconsole) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-qtconsole--base-green.svg)](https://anaconda.org/conda-forge/qtconsole-base) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/qtconsole-base.svg)](https://anaconda.org/conda-forge/qtconsole-base) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/qtconsole-base.svg)](https://anaconda.org/conda-forge/qtconsole-base) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/qtconsole-base.svg)](https://anaconda.org/conda-forge/qtconsole-base) |
 
 Installing qtconsole
 ====================
@@ -51,10 +52,10 @@ conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `qtconsole` can be installed with:
+Once the `conda-forge` channel has been enabled, `qtconsole, qtconsole-base` can be installed with:
 
 ```
-conda install qtconsole
+conda install qtconsole qtconsole-base
 ```
 
 It is possible to list all of the versions of `qtconsole` available on your platform with:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set version = "5.2.2" %}
 
 package:
-  name: qtconsole
+  name: qtconsole-base
   version: {{ version }}
 
 source:
@@ -10,7 +10,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . --no-deps -vv
   entry_points:
     - jupyter-qtconsole = qtconsole.qtconsoleapp:main
@@ -21,7 +21,6 @@ requirements:
     - pip
   run:
     - python >=3.6
-    - pyqt
     - traitlets
     - ipython_genutils
     - jupyter_core
@@ -37,6 +36,19 @@ test:
   imports:
     - qtconsole
     - qtconsole.tests
+
+outputs:
+  - name: qtconsole-base
+  - name: qtconsole
+    build:
+      noarch: python
+    requirements:
+      host:
+        - python >=3.6
+      run:
+        - python >=3.6
+        - {{ pin_subpackage('qtconsole-base', exact=True) }}
+        - pyqt
 
 about:
   home: http://jupyter.org
@@ -62,3 +74,4 @@ extra:
     - minrk
     - takluyver
     - ocefpaf
+  feedstock-name: qtconsole

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,9 +30,10 @@ requirements:
     - qtpy
 
 test:
+  requires:
+    - pyqt
   commands:
     - DISPLAY=localhost:1.0 xvfb-run -a bash -c 'jupyter qtconsole --help'
-
   imports:
     - qtconsole
     - qtconsole.tests

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,7 +44,7 @@ outputs:
         - python >=3.6
       run:
         - python >=3.6
-        - {{ pin_subpackage('qtconsole-base', exact=True) }}
+        - {{ pin_subpackage('qtconsole-base', max_pin='x.x.x') }}
         - pyqt
     test:
       commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,10 +30,6 @@ requirements:
     - qtpy
 
 test:
-  requires:
-    - pyqt
-  commands:
-    - DISPLAY=localhost:1.0 xvfb-run -a bash -c 'jupyter qtconsole --help'
   imports:
     - qtconsole
     - qtconsole.tests
@@ -50,6 +46,9 @@ outputs:
         - python >=3.6
         - {{ pin_subpackage('qtconsole-base', exact=True) }}
         - pyqt
+    test:
+      commands:
+        - DISPLAY=localhost:1.0 xvfb-run -a bash -c 'jupyter qtconsole --help'
 
 about:
   home: http://jupyter.org


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [X] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Supersedes #27. This should allow other packages to depend on `qtconsole-base` so they can use `pyside2` if needed.